### PR TITLE
Atualiza a versão da gem brakeman de 6.2.2 para 7.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (6.2.2)
+    brakeman (7.0.0)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
chore(Gemfile.lock): atualiza a versão da gem brakeman de 6.2.2 para 7.0.0 para melhorar a segurança e a compatibilidade.