### PR TITLE
Redireciona usuários autenticados para a página inicial

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,7 @@ class SessionsController < ApplicationController
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
   def new
+    redirect_to root_path if authenticated?
   end
 
   def create

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,5 +2,5 @@
 
 discipline = FactoryBot.create(:discipline, title: 'Introdução a linguagem GO')
 FactoryBot.create_list(:content, 5, discipline: discipline, kind: :text)
-FactoryBot.create(:user, email_address: 'student@spacedevs.com.br', password: '123', role: :student)
+FactoryBot.create(:user, email_address: 'student@spacedevs.com.br', password: '123', role: :student, registration_code: 'SDS6658093H')
 FactoryBot.create(:user, email_address: 'manager@spacedevs.com.br', password: '123', role: :manager)

--- a/spec/system/authentication/authentication_spec.rb
+++ b/spec/system/authentication/authentication_spec.rb
@@ -23,4 +23,13 @@ feature 'Authentication' do
     expect(status_code).to eq 200
     expect(page).to have_field 'Matricula'
   end
+
+  scenario 'already authenticated user cannot view session page' do
+    user = create(:user, :student)
+
+    login_as(user)
+    visit new_session_path
+
+    expect(current_path).to eq root_path
+  end
 end


### PR DESCRIPTION
## 🦉 Implementação

Melhora a experiência do usuário redirecionando-o para a página principal quando ele tenta acessar a página de login.

## ✅ Proposta

- [x] redireciona usuários autenticados para a página inicial
- [x] fix(seeds.rb): adiciona código de registro ao usuário estudante no seed
- [x] test(authentication_spec.rb): adiciona teste para usuário autenticado não acessar a página de sessão

