### PR TITLE
Adiciona exibição de disciplinas no dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,5 +2,6 @@ class DashboardController < ApplicationController
   before_action :authenticated?, only: :index
 
   def index
+    @disciplines = Discipline.all
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,6 +2,6 @@ class DashboardController < ApplicationController
   before_action :authenticated?, only: :index
 
   def index
-    @disciplines = Discipline.all
+    @disciplines = Discipline.all.order(:position)
   end
 end

--- a/app/models/discipline.rb
+++ b/app/models/discipline.rb
@@ -1,4 +1,4 @@
 class Discipline < ApplicationRecord
-  validates :title, :abstract,  presence: true
-  validates :title,             uniqueness: true
+  validates :title, :abstract, :position,  presence: true
+  validates :title, uniqueness: true
 end

--- a/app/views/dashboard/index.erb
+++ b/app/views/dashboard/index.erb
@@ -1,3 +1,0 @@
-<h1>Olá Spacer, seja bem-vindo!</h1>
-
-<%= link_to 'Sair', session_path, { method: :delete } %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,0 +1,12 @@
+<h1>Olá Spacer, seja bem-vindo!</h1>
+
+<div id="disciplines">
+<% @disciplines.each do | discipline | %>
+  <div>
+    <h2><%= discipline.title %></h2>
+    <p><%= discipline.abstract %></p>
+  </div>
+<% end %>
+</div>
+
+<%= link_to 'Sair', session_path, { method: :delete } %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,12 +1,16 @@
 <h1>Olá Spacer, seja bem-vindo!</h1>
 
 <div id="disciplines">
-<% @disciplines.each do | discipline | %>
+
+<% if @disciplines.blank? %>
+  <p>Nenhuma disciplina disponível.</p>
+<% end %>
+
+<% @disciplines.each do |discipline|  %>
   <div>
     <h2><%= discipline.title %></h2>
     <p><%= discipline.abstract %></p>
   </div>
 <% end %>
-</div>
 
 <%= link_to 'Sair', session_path, { method: :delete } %>

--- a/db/migrate/20241231181214_add_position_to_discipline.rb
+++ b/db/migrate/20241231181214_add_position_to_discipline.rb
@@ -1,0 +1,5 @@
+class AddPositionToDiscipline < ActiveRecord::Migration[8.0]
+  def change
+    add_column :disciplines, :position, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_31_115334) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_31_181214) do
   create_table "contents", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -27,6 +27,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_31_115334) do
     t.string "abstract", limit: 120
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "position", default: 1
     t.index ["title"], name: "index_disciplines_on_title", unique: true
   end
 

--- a/spec/models/discipline_spec.rb
+++ b/spec/models/discipline_spec.rb
@@ -3,8 +3,16 @@ require 'rails_helper'
 RSpec.describe Discipline, type: :model do
   context 'validations' do
     it { is_expected.to validate_presence_of(:title) }
-    it { is_expected.to validate_presence_of(:abstract)
-  }
+    it { is_expected.to validate_presence_of(:abstract) }
+    it { is_expected.to validate_presence_of(:position) }
     it { is_expected.to validate_uniqueness_of(:title) }
+  end
+
+  context '#discipline' do
+    let(:discipline) { create(:discipline) }
+
+    it 'position default must be 1' do
+      expect(discipline.position).to eq(1)
+    end
   end
 end

--- a/spec/system/dashboard/disciplines/list_spec.rb
+++ b/spec/system/dashboard/disciplines/list_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'Disciplines' do
-  scenario 'student must view disciplines' do
+  scenario 'student must see disciplines' do
     user = create(:user, :student)
     create(:discipline, title: 'Introdução a tecnologia', abstract: 'Neste módulo você aprenderá sobre a história da tecnologia e sua importância para a sociedade.')
     create(:discipline, title: 'Arquitetura de computadores', abstract: 'Neste módulo você aprenderá sobre a arquitetura de computadores e como eles funcionam.')
@@ -19,7 +19,7 @@ feature 'Disciplines' do
     end
   end
 
-  scenario 'student must view disciplines on ordered' do
+  scenario 'student must see disciplines on ordered' do
     user = create(:user, :student)
     discipline = create(:discipline, title: 'Introdução a tecnologia',     position: 2)
     discipline2 = create(:discipline, title: 'Arquitetura de computadores', position: 1)
@@ -33,5 +33,14 @@ feature 'Disciplines' do
     within '#disciplines > div:nth-child(1)' do
       expect(page).to have_content(discipline2.title)
     end
+  end
+
+  scenario 'student should see the message nothing to display' do
+    user = create(:user, :student)
+
+    login_as(user)
+    visit root_path
+
+    expect(page).to have_content('Nenhuma disciplina disponível')
   end
 end

--- a/spec/system/dashboard/disciplines/list_spec.rb
+++ b/spec/system/dashboard/disciplines/list_spec.rb
@@ -18,4 +18,20 @@ feature 'Disciplines' do
       expect(page).to have_content('Neste módulo você aprenderá sobre a arquitetura de computadores e como eles funcionam.')
     end
   end
+
+  scenario 'student must view disciplines on ordered' do
+    user = create(:user, :student)
+    discipline = create(:discipline, title: 'Introdução a tecnologia',     position: 2)
+    discipline2 = create(:discipline, title: 'Arquitetura de computadores', position: 1)
+
+    login_as(user)
+    visit root_path
+
+    within '#disciplines > div:nth-child(2)' do
+      expect(page).to have_content(discipline.title)
+    end
+    within '#disciplines > div:nth-child(1)' do
+      expect(page).to have_content(discipline2.title)
+    end
+  end
 end

--- a/spec/system/dashboard/disciplines/list_spec.rb
+++ b/spec/system/dashboard/disciplines/list_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+feature 'Disciplines' do
+  scenario 'student must view disciplines' do
+    user = create(:user, :student)
+    create(:discipline, title: 'Introdução a tecnologia', abstract: 'Neste módulo você aprenderá sobre a história da tecnologia e sua importância para a sociedade.')
+    create(:discipline, title: 'Arquitetura de computadores', abstract: 'Neste módulo você aprenderá sobre a arquitetura de computadores e como eles funcionam.')
+
+    login_as(user)
+    visit root_path
+
+    within '#disciplines > div:nth-child(1)' do
+      expect(page).to have_content('Introdução a tecnologia')
+      expect(page).to have_content('Neste módulo você aprenderá sobre a história da tecnologia e sua importância para a sociedade.')
+    end
+    within '#disciplines > div:nth-child(2)' do
+      expect(page).to have_content('Arquitetura de computadores')
+      expect(page).to have_content('Neste módulo você aprenderá sobre a arquitetura de computadores e como eles funcionam.')
+    end
+  end
+end


### PR DESCRIPTION
## ⛏️ Motivação

Estudantes devem visualizar as disciplinas que estão disponíveis para cursar no dashboard.

## ✅ Proposta

- feat(dashboard): adiciona mensagem quando não há disciplinas disponíveis
- test(dashboard): atualiza cenários de teste para refletir mudanças na exibição
- feat(dashboard): adiciona ordenação de disciplinas por posição
- feat(discipline): adiciona validação de presença para a posição
- feat(migration): cria migração para adicionar coluna de posição à tabela de disciplinas
- test(discipline_spec): adiciona teste para verificar a posição padrão
- test(list_spec): adiciona teste para garantir que disciplinas são exibidas em ordem
- feat(dashboard): adiciona exibição de disciplinas no dashboard do usuário
- refactor(dashboard): substitui a view index.erb por index.html.erb para melhor estruturação
- test(dashboard): cria teste para verificar a exibição das disciplinas no dashboard

## Foi testado?

- [x] Sim.
- [ ] Não.
