### PR TITLE
chore(schema): atualiza schema para versão 2024_12_31_201734

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_31_181214) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_31_201734) do
   create_table "contents", force: :cascade do |t|
     t.string "title"
     t.text "body"


### PR DESCRIPTION
## ⛏️ Motivação
Atualiza schema para versão 2024_12_31_201734. Isto ocorreu por não  ter enviado a atualização do schema juntamente com o último commit  [a6c4658](https://github.com/spacdevs/spacedevs/commit/a6c46584351927d71fe05b1577a886257ef72fc9)

## ✅ Proposta

Correção na versão do schema migrada para o banco de dados

## Foi testado?

- [x] Sim.
- [ ] Não.
