### PR TITLE
Feat/add profile to user

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,16 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+
+  validates :first_name, :last_name, :birthday, :degree, presence: true
+
+  enum :degree, first_year: 1, second_year: 2, third_year: 3
+
+  before_create :generate_avatar
+
+  private
+
+  def generate_avatar
+    hash = Digest::MD5.hexdigest(user.email_address.downcase)
+    self.avatar = "https://www.gravatar.com/avatar/#{hash}"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
+  has_one  :profile, dependent: :destroy
 
   normalizes :email_address, with: ->(e) { e.strip.downcase }
 

--- a/config/locales/profiles_pt-BR.yml
+++ b/config/locales/profiles_pt-BR.yml
@@ -1,0 +1,12 @@
+---
+pt-BR:
+  activerecord:
+    models:
+      profile: Perfil
+    attributes:
+      profile:
+        first_name: 'Nome'
+      degrees:
+        first_year: "1º ano do ensino médio"
+        second_year: "2º ano do ensino médio"
+        third_year:  "3º ano do ensino médio"

--- a/db/migrate/20250105173240_create_profiles.rb
+++ b/db/migrate/20250105173240_create_profiles.rb
@@ -1,0 +1,15 @@
+class CreateProfiles < ActiveRecord::Migration[8.0]
+  def change
+    create_table :profiles do |t|
+      t.string :first_name, null: false
+      t.string :last_name, null: false
+      t.string :document, null: false
+      t.string :avatar
+      t.datetime :birthday, null: false
+      t.integer :degree
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_31_201734) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_05_173240) do
   create_table "contents", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -29,6 +29,19 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_31_201734) do
     t.datetime "updated_at", null: false
     t.integer "position", default: 1
     t.index ["title"], name: "index_disciplines_on_title", unique: true
+  end
+
+  create_table "profiles", force: :cascade do |t|
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "document", null: false
+    t.string "avatar"
+    t.datetime "birthday", null: false
+    t.integer "degree"
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -52,5 +65,6 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_31_201734) do
   end
 
   add_foreign_key "contents", "disciplines"
+  add_foreign_key "profiles", "users"
   add_foreign_key "sessions", "users"
 end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :profile do
+    first_name { Faker::Name.first_name }
+    last_name  { Faker::Name.last_name }
+    document   { Faker::IdNumber.brazilian_citizen_number }
+    avatar     { Faker::Avatar.image }
+    birthday   { Faker::Date.birthday }
+    degree     { %i[first_year second_year third_year].sample }
+    user
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,4 +4,10 @@ FactoryBot.define do
     email_address     { Faker::Internet.email }
     password          { Faker::Internet.password }
   end
+
+  trait :with_profile do
+    before :create do |user|
+      user.profile = create(:profile, sourceable: user)
+    end
+  end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Profile, type: :model do
+  context 'validates' do
+    it { is_expected.to validate_presence_of(:first_name).with_message('não pode ficar em branco') }
+    it { is_expected.to validate_presence_of(:last_name).with_message('não pode ficar em branco') }
+    it { is_expected.to validate_presence_of(:birthday).with_message('não pode ficar em branco') }
+    it { is_expected.to validate_presence_of(:degree).with_message('não pode ficar em branco') }
+  end
+
+  context 'associations' do
+    it { is_expected.to belong_to(:user) }
+  end
+
+  context 'enums' do
+    it { is_expected.to define_enum_for(:degree).with_values(first_year: 1, second_year: 2, third_year: 3) }
+  end
+
+  context 'when the user have avatar' do
+    let(:profile) { create(:profile) }
+
+    it { expect(profile.avatar).to be_present }
+    it { expect(profile.avatar).to include('gravatar') }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe User, type: :model do
     it { is_expected.to validate_presence_of(:registration_code) }
     it { is_expected.to have_many(:sessions) }
     it { is_expected.to define_enum_for(:role).with_values(manager: 0, student: 1) }
+    it { is_expected.to have_one(:profile) }
   end
 
   context 'auto generate registration code' do


### PR DESCRIPTION
## ⛏️ Motivação
Adiciona modelo de perfil que faz relação com usuário, sendo assim, o usuário pode ter informações adicionais como nome, grau de escolaridade, avatar e etc.

## ✅ Proposta
Criar modelo de perfil que tem relação com usuário. Se faz necessário para adicionar informações extras do usuário como por exemplo, nome, gráu de escolaridade, cpf, imagens e etc.

## Foi testado?

- [x] Sim.
- [ ] Não.
