### PR TITLE
Limita a quantidade de usuários apresentado na lista da página admini…

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -28,7 +28,7 @@ module Admin
     private
 
     def set_users
-      @users = User.includes(:profile).student.order('profiles.first_name, profiles.last_name ASC')
+      @users = User.includes(:profile).student.order('profiles.first_name, profiles.last_name ASC').limit(10)
     end
 
     def q

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -30,7 +30,7 @@
         </thead>
         <tbody>
           <% @users.each do |user| %>
-            <tr>
+            <tr class="user">
               <th class="uk-width-small">
                 <%= user.profile.fullname %>
               </th>

--- a/spec/system/admin/users/index_spec.rb
+++ b/spec/system/admin/users/index_spec.rb
@@ -9,7 +9,7 @@ feature Admin::UsersController do
     expect(page).to have_content('Administração')
   end
 
-  scenario 'admin view registered users' do
+  scenario 'admin sees students' do
     student = create(:user, :with_profile, :student)
 
     login_as(admin)
@@ -21,7 +21,16 @@ feature Admin::UsersController do
     expect(page).to have_content(I18n.l(student.created_at, format: :short))
   end
 
-  scenario 'admin view ordered users' do
+  scenario 'admin sees only 10 students' do
+    create_list(:user, 15, :with_profile, :student)
+
+    login_as(admin)
+    click_on 'Alunos'
+
+    expect(page).to have_css('.user', count: 10)
+  end
+
+  scenario 'admin sees ordered users' do
     user1 = create(:user, :with_profile, :student)
     user2 = create(:user, :with_profile, :student)
     user1.profile.update!(first_name: 'Marcelo', last_name: 'Aguiar')
@@ -63,7 +72,7 @@ feature Admin::UsersController do
     expect(page).not_to have_content('Simão Silva')
   end
 
-  scenario 'cannot view admin user' do
+  scenario 'cannot sees admin user' do
     login_as(admin)
     click_on 'Alunos'
 
@@ -72,7 +81,7 @@ feature Admin::UsersController do
     end
   end
 
-  scenario 'student cannot view others registered students' do
+  scenario 'student cannot sees others registered students' do
     student = create(:user, :with_profile, :student)
 
     login_as(student)


### PR DESCRIPTION
## ⛏️ Motivação
Mostrar apenas 10 usuários na lista dentro da página administrativa de gerenciamento de usuários

## ✅ Proposta

feat(users_controller.rb): limita a lista de usuários a 10 na ação set_users
style(index.html.erb): adiciona classe "user" às linhas da tabela de usuários
test(users_spec.rb): atualiza cenários para refletir a limitação de 10 usuários e melhora a descrição dos testes

## 🌄 Imagens
