### PR TITLE
feat(admin/users): adiciona colunas de colégio, turma e data de cadas…

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -25,7 +25,9 @@
           <tr>
               <th class="uk-width-small">Nome completo</th>
               <th>E-mail</th>
-              <th>Data de criação</th>
+              <th>Colégio</th>
+              <th>Turma</th>
+              <th>Data de cadastro</th>
           </tr>
         </thead>
         <tbody>
@@ -39,6 +41,12 @@
               </th>
               <th>
                 <%= I18n.l(user.created_at, format: :short) %>
+              </th>
+              <th>
+                <%= user.school.name %>
+              </th>
+              <th>
+              <%= Profile.human_enum_name(:degree, user.profile.degree) %>
               </th>
               <th>
                 <% if user.disabled_at.present? %>

--- a/spec/system/admin/users/index_spec.rb
+++ b/spec/system/admin/users/index_spec.rb
@@ -10,7 +10,9 @@ feature Admin::UsersController do
   end
 
   scenario 'admin sees students' do
-    student = create(:user, :with_profile, :student)
+    school = create(:school, name: 'Colégio Estadual Governador Roberto Santos')
+    student = create(:user, :with_profile, :student, school:)
+    student.profile.update!(degree: :first_year)
 
     login_as(admin)
     click_on 'Alunos'
@@ -19,6 +21,8 @@ feature Admin::UsersController do
     expect(page).to have_content(student.profile.fullname)
     expect(page).to have_content(student.email)
     expect(page).to have_content(I18n.l(student.created_at, format: :short))
+    expect(page).to have_content('Colégio Estadual Governador Roberto Santos')
+    expect(page).to have_content('1º ano do ensino médio')
   end
 
   scenario 'admin sees only 10 students' do


### PR DESCRIPTION
## ⛏️ Motivação
Mostrar informações do colégio e série que o aluno está cursando.

## ✅ Proposta
feat(admin/users): adiciona colunas de colégio, turma e data de cadastro na tabela de usuários
test(admin/users): atualiza teste para verificar colégio e turma dos alunos na lista

## 🌄 Imagens
![Screenshot 2025-02-22 at 16 15 52](https://github.com/user-attachments/assets/88f650db-a00a-4cc2-8aba-db4b4ef5495f)

## 🗂️ Arquivos

- spec/system/admin/users/index_spec.rb
- app/views/admin/users/index.html.erb