### PR TITLE
Refatoração - nomalização das migrações

### DIFF
--- a/app/models/discipline.rb
+++ b/app/models/discipline.rb
@@ -3,7 +3,7 @@
 class Discipline < ApplicationRecord
   has_many :contents, dependent: :destroy
 
-  validates :title, :body, :abstract, :position, :slug, presence: true
+  validates :title, :body, :abstract, :position, :slug, :available_on, presence: true
 
   before_validation :update_slug
 

--- a/db/migrate/20241201182415_create_discipline.rb
+++ b/db/migrate/20241201182415_create_discipline.rb
@@ -1,9 +1,12 @@
 class CreateDiscipline < ActiveRecord::Migration[8.0]
   def change
     create_table :disciplines do |t|
-      t.string :title,    index: { unique: true }
-      t.string :abstract, limit: 120
-
+      t.string  :title,    index: { unique: true }
+      t.string  :abstract, limit: 120
+      t.integer :position, default: 1
+      t.string  :slug, index: { unique: true }
+      t.text    :body
+      t.datetime :available_on, :datetime
       t.timestamps
     end
   end

--- a/db/migrate/20241201212435_create_contents.rb
+++ b/db/migrate/20241201212435_create_contents.rb
@@ -5,6 +5,7 @@ class CreateContents < ActiveRecord::Migration[8.0]
       t.text       :body
       t.references :discipline, null: false, foreign_key: true
       t.integer    :kind, default: 1
+      t.string :slug, index: { unique: true }
 
       t.timestamps
     end

--- a/db/migrate/20241231115334_add_available_to_content.rb
+++ b/db/migrate/20241231115334_add_available_to_content.rb
@@ -1,5 +1,0 @@
-class AddAvailableToContent < ActiveRecord::Migration[8.0]
-  def change
-    add_column :contents, :available_on, :datetime
-  end
-end

--- a/db/migrate/20241231181214_add_position_to_discipline.rb
+++ b/db/migrate/20241231181214_add_position_to_discipline.rb
@@ -1,5 +1,0 @@
-class AddPositionToDiscipline < ActiveRecord::Migration[8.0]
-  def change
-    add_column :disciplines, :position, :integer, default: 1
-  end
-end

--- a/db/migrate/20250105224336_add_slug_to_disciplines.rb
+++ b/db/migrate/20250105224336_add_slug_to_disciplines.rb
@@ -1,6 +1,0 @@
-class AddSlugToDisciplines < ActiveRecord::Migration[8.0]
-  def change
-    add_column :disciplines, :slug, :string
-    add_index :disciplines, :slug, unique: true
-  end
-end

--- a/db/migrate/20250109184158_add_slug_to_contents.rb
+++ b/db/migrate/20250109184158_add_slug_to_contents.rb
@@ -1,6 +1,0 @@
-class AddSlugToContents < ActiveRecord::Migration[8.0]
-  def change
-    add_column :contents, :slug, :string
-    add_index :contents, :slug, unique: true
-  end
-end

--- a/db/migrate/20250123065042_add_body_to_disciplines.rb
+++ b/db/migrate/20250123065042_add_body_to_disciplines.rb
@@ -1,5 +1,0 @@
-class AddBodyToDisciplines < ActiveRecord::Migration[8.0]
-  def change
-    add_column :disciplines, :body, :text
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,20 +20,22 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
     t.datetime "updated_at", null: false
     t.datetime "available_on"
     t.string "slug"
-    t.index ["discipline_id"], name: "index_contents_on_discipline_id"
-    t.index ["slug"], name: "index_contents_on_slug", unique: true
+    t.index [ "discipline_id" ], name: "index_contents_on_discipline_id"
+    t.index [ "slug" ], name: "index_contents_on_slug", unique: true
   end
 
   create_table "disciplines", force: :cascade do |t|
     t.string "title"
     t.string "abstract", limit: 120
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "position", default: 1
     t.string "slug"
     t.text "body"
-    t.index ["slug"], name: "index_disciplines_on_slug", unique: true
-    t.index ["title"], name: "index_disciplines_on_title", unique: true
+    t.datetime "available_on"
+    t.datetime "datetime"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "slug" ], name: "index_disciplines_on_slug", unique: true
+    t.index [ "title" ], name: "index_disciplines_on_title", unique: true
   end
 
   create_table "profiles", force: :cascade do |t|
@@ -47,8 +49,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug", null: false
-    t.index ["slug"], name: "index_profiles_on_slug", unique: true
-    t.index ["user_id"], name: "index_profiles_on_user_id"
+    t.index [ "slug" ], name: "index_profiles_on_slug", unique: true
+    t.index [ "user_id" ], name: "index_profiles_on_user_id"
   end
 
   create_table "schools", force: :cascade do |t|
@@ -64,7 +66,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
     t.string "user_agent"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_sessions_on_user_id"
+    t.index [ "user_id" ], name: "index_sessions_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -76,9 +78,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
     t.datetime "updated_at", null: false
     t.integer "school_id", null: false
     t.datetime "disabled_at"
-    t.index ["email_address"], name: "index_users_on_email_address", unique: true
-    t.index ["registration_code"], name: "index_users_on_registration_code", unique: true
-    t.index ["school_id"], name: "index_users_on_school_id"
+    t.index [ "email_address" ], name: "index_users_on_email_address", unique: true
+    t.index [ "registration_code" ], name: "index_users_on_registration_code", unique: true
+    t.index [ "school_id" ], name: "index_users_on_school_id"
   end
 
   add_foreign_key "contents", "disciplines"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,12 +16,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
     t.text "body"
     t.integer "discipline_id", null: false
     t.integer "kind", default: 1
+    t.string "slug"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "available_on"
-    t.string "slug"
-    t.index [ "discipline_id" ], name: "index_contents_on_discipline_id"
-    t.index [ "slug" ], name: "index_contents_on_slug", unique: true
+    t.index ["discipline_id"], name: "index_contents_on_discipline_id"
+    t.index ["slug"], name: "index_contents_on_slug", unique: true
   end
 
   create_table "disciplines", force: :cascade do |t|
@@ -34,8 +33,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
     t.datetime "datetime"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "slug" ], name: "index_disciplines_on_slug", unique: true
-    t.index [ "title" ], name: "index_disciplines_on_title", unique: true
+    t.index ["slug"], name: "index_disciplines_on_slug", unique: true
+    t.index ["title"], name: "index_disciplines_on_title", unique: true
   end
 
   create_table "profiles", force: :cascade do |t|
@@ -49,8 +48,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "slug", null: false
-    t.index [ "slug" ], name: "index_profiles_on_slug", unique: true
-    t.index [ "user_id" ], name: "index_profiles_on_user_id"
+    t.index ["slug"], name: "index_profiles_on_slug", unique: true
+    t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
   create_table "schools", force: :cascade do |t|
@@ -66,7 +65,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
     t.string "user_agent"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index [ "user_id" ], name: "index_sessions_on_user_id"
+    t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -78,9 +77,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
     t.datetime "updated_at", null: false
     t.integer "school_id", null: false
     t.datetime "disabled_at"
-    t.index [ "email_address" ], name: "index_users_on_email_address", unique: true
-    t.index [ "registration_code" ], name: "index_users_on_registration_code", unique: true
-    t.index [ "school_id" ], name: "index_users_on_school_id"
+    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["registration_code"], name: "index_users_on_registration_code", unique: true
+    t.index ["school_id"], name: "index_users_on_school_id"
   end
 
   add_foreign_key "contents", "disciplines"

--- a/spec/factories/contents.rb
+++ b/spec/factories/contents.rb
@@ -4,6 +4,5 @@ FactoryBot.define do
     body { Faker::Movie.quote }
     discipline
     kind { %i[text video].sample }
-    available_on { Time.zone.now }
   end
 end

--- a/spec/factories/disciplines.rb
+++ b/spec/factories/disciplines.rb
@@ -1,8 +1,9 @@
 FactoryBot.define do
   factory :discipline do
-    title     { Faker::Movie.title    }
-    body  { Faker::Lorem.sentence }
-    abstract  { Faker::Lorem.sentence }
+    title { Faker::Movie.title }
+    body { Faker::Lorem.sentence }
+    abstract { Faker::Lorem.sentence }
+    available_on { 5.days.after }
 
     trait :with_contents do
       transient do

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -12,17 +12,6 @@ RSpec.describe Content, type: :model do
     it { is_expected.to belong_to(:discipline) }
   end
 
-  context 'should set available attribute' do
-    let(:content)   do
-      travel_to Time.zone.local(2024, 12, 31, 12, 0, 0) do
-        create(:content)
-      end
-    end
-
-    it { expect(content.available_on).to be_present }
-    it { expect(I18n.l(content.available_on, format: :short)).to eq "31 de dezembro, 12:00" }
-  end
-
   context 'when has slug' do
     let(:content) { create(:content, title: 'Hello World') }
 

--- a/spec/models/discipline_spec.rb
+++ b/spec/models/discipline_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Discipline, type: :model do
     it { is_expected.to validate_presence_of(:abstract) }
     it { is_expected.to validate_presence_of(:position) }
     it { is_expected.to validate_presence_of(:slug) }
+    it { is_expected.to validate_presence_of(:available_on) }
   end
 
   context 'association' do

--- a/spec/models/discipline_spec.rb
+++ b/spec/models/discipline_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe Discipline, type: :model do
     it { is_expected.to have_many(:contents) }
   end
 
+  context 'should set available attribute' do
+    let(:discipline) { create(:discipline, available_on: Time.zone.local(2024, 12, 31, 12, 0, 0)) }
+
+    it { expect(discipline.available_on).to be_present }
+    it { expect(I18n.l(discipline.available_on, format: :short)).to eq "31 de dezembro, 12:00" }
+  end
+
+
   context '#discipline' do
     let(:discipline) { create(:discipline) }
 


### PR DESCRIPTION
## ⛏️ Motivação
Atualmente foram criadas migrações adicionais para incluir campos necessários.

## ✅ Proposta
Remover as migrações que criavam campos adicionais nas migrações já existentes(users, profiles, disciplines e contents).
Adiciona campos que eram criados na migrações adicionais nas migrações pais.

## 📝 Notas
Sei que o processo de remoção das migrações já existentes, não é algo natural, mas como o projeto não está no **AR** as migrações foram removidas para serem padronizadas. Quando o projeto estiver no **AR** isso não pode acontecer, fere os princípios da implementação de migrações na aplicação.  
