### PR TITLE
Cria turmas, associa disciplinas a ela e permite que alunos naveguem entre as turmas

### DIFF
--- a/app/models/discipline.rb
+++ b/app/models/discipline.rb
@@ -2,6 +2,8 @@
 
 class Discipline < ApplicationRecord
   has_many :contents, dependent: :destroy
+  has_many   :team_disciplines, dependent: :destroy
+  has_many   :teams, through: :team_disciplines
 
   validates :title, :body, :abstract, :position, :slug, :available_on, presence: true
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -3,6 +3,8 @@
 class Team < ApplicationRecord
   has_many   :team_users, dependent: :destroy
   has_many   :users, through: :team_users
+  has_many   :team_disciplines, dependent: :destroy
+  has_many   :disciplines, through: :team_disciplines
 
   validates :name, presence: true
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
 class Team < ApplicationRecord
-  has_many :team_users_discipline
-  has_many :users, through: :team_users_discipline
-  has_many :disciplines, through: :team_users_discipline
-
   validates :name, presence: true
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Team < ApplicationRecord
+  has_many :team_users_discipline
+  has_many :users, through: :team_users_discipline
+  has_many :disciplines, through: :team_users_discipline
+
+  validates :name, presence: true
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 class Team < ApplicationRecord
+  has_many   :team_users, dependent: :destroy
+  has_many   :users, through: :team_users
+
   validates :name, presence: true
 end

--- a/app/models/team_discipline.rb
+++ b/app/models/team_discipline.rb
@@ -1,0 +1,4 @@
+class TeamDiscipline < ApplicationRecord
+  belongs_to :discipline
+  belongs_to :team
+end

--- a/app/models/team_discipline.rb
+++ b/app/models/team_discipline.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TeamDiscipline < ApplicationRecord
   belongs_to :discipline
   belongs_to :team

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class TeamUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :team
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   belongs_to :school
   has_one    :profile, dependent: :destroy
   has_many   :sessions, dependent: :destroy
+  has_many   :team_users, dependent: :destroy
+  has_many   :teams, through: :team_users
 
   alias_attribute :email, :email_address
 

--- a/db/migrate/20241204151559_create_users.rb
+++ b/db/migrate/20241204151559_create_users.rb
@@ -5,6 +5,8 @@ class CreateUsers < ActiveRecord::Migration[8.0]
       t.string  :registration_code, null: false
       t.integer :role,              null: false, default: 0
       t.string  :password_digest,   null: false
+      t.datetime :disabled_at,      null: true
+      t.references :school, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20250131093157_add_school_to_user.rb
+++ b/db/migrate/20250131093157_add_school_to_user.rb
@@ -1,5 +1,0 @@
-class AddSchoolToUser < ActiveRecord::Migration[8.0]
-  def change
-    add_reference :users, :school, null: false, foreign_key: true
-  end
-end

--- a/db/migrate/20250219113450_add_disabled_at_to_user.rb
+++ b/db/migrate/20250219113450_add_disabled_at_to_user.rb
@@ -1,5 +1,0 @@
-class AddDisabledAtToUser < ActiveRecord::Migration[8.0]
-  def change
-    add_column :users, :disabled_at, :datetime
-  end
-end

--- a/db/migrate/20250223230439_create_teams.rb
+++ b/db/migrate/20250223230439_create_teams.rb
@@ -1,0 +1,10 @@
+class CreateTeams < ActiveRecord::Migration[8.0]
+  def change
+    create_table :teams do |t|
+      t.string :name
+      t.boolean :active, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250223232322_create_team_users.rb
+++ b/db/migrate/20250223232322_create_team_users.rb
@@ -1,0 +1,10 @@
+class CreateTeamUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :team_users do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :team, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250223233858_create_team_disciplines.rb
+++ b/db/migrate/20250223233858_create_team_disciplines.rb
@@ -1,0 +1,10 @@
+class CreateTeamDisciplines < ActiveRecord::Migration[8.0]
+  def change
+    create_table :team_disciplines do |t|
+      t.references :discipline, null: false, foreign_key: true
+      t.references :team, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_23_232322) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_23_233858) do
   create_table "contents", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -68,6 +68,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_23_232322) do
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
+  create_table "team_disciplines", force: :cascade do |t|
+    t.integer "discipline_id", null: false
+    t.integer "team_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["discipline_id"], name: "index_team_disciplines_on_discipline_id"
+    t.index ["team_id"], name: "index_team_disciplines_on_team_id"
+  end
+
   create_table "team_users", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "team_id", null: false
@@ -101,6 +110,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_23_232322) do
   add_foreign_key "contents", "disciplines"
   add_foreign_key "profiles", "users"
   add_foreign_key "sessions", "users"
+  add_foreign_key "team_disciplines", "disciplines"
+  add_foreign_key "team_disciplines", "teams"
   add_foreign_key "team_users", "teams"
   add_foreign_key "team_users", "users"
   add_foreign_key "users", "schools"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_22_234906) do
   create_table "contents", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -68,15 +68,22 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_113450) do
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
+  create_table "teams", force: :cascade do |t|
+    t.string "name"
+    t.boolean "active"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email_address", null: false
     t.string "registration_code", null: false
     t.integer "role", default: 0, null: false
     t.string "password_digest", null: false
+    t.datetime "disabled_at"
+    t.integer "school_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "school_id", null: false
-    t.datetime "disabled_at"
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["registration_code"], name: "index_users_on_registration_code", unique: true
     t.index ["school_id"], name: "index_users_on_school_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_22_234906) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_23_230439) do
   create_table "contents", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -70,7 +70,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_22_234906) do
 
   create_table "teams", force: :cascade do |t|
     t.string "name"
-    t.boolean "active"
+    t.boolean "active", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_23_230439) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_23_232322) do
   create_table "contents", force: :cascade do |t|
     t.string "title"
     t.text "body"
@@ -68,6 +68,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_23_230439) do
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
+  create_table "team_users", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "team_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["team_id"], name: "index_team_users_on_team_id"
+    t.index ["user_id"], name: "index_team_users_on_user_id"
+  end
+
   create_table "teams", force: :cascade do |t|
     t.string "name"
     t.boolean "active", default: false
@@ -92,5 +101,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_23_230439) do
   add_foreign_key "contents", "disciplines"
   add_foreign_key "profiles", "users"
   add_foreign_key "sessions", "users"
+  add_foreign_key "team_users", "teams"
+  add_foreign_key "team_users", "users"
   add_foreign_key "users", "schools"
 end

--- a/spec/factories/team_disciplines.rb
+++ b/spec/factories/team_disciplines.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :team_discipline do
+    discipline
+    team
+  end
+end

--- a/spec/factories/team_users.rb
+++ b/spec/factories/team_users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :team_user do
+    user
+    team
+  end
+end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :team do
+    name { Faker::Team.name }
+    active { false }
+  end
+end

--- a/spec/models/discipline_spec.rb
+++ b/spec/models/discipline_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe Discipline, type: :model do
 
   context 'association' do
     it { is_expected.to have_many(:contents) }
+    it { is_expected.to have_many(:teams) }
+  end
+
+  context 'discipline is on multiple teams' do
+    let(:discipline) { create(:discipline) }
+
+    before do
+      create_list(:team, 3, disciplines: [ discipline ])
+      discipline.reload
+    end
+
+    it { expect(discipline.teams.size).to eq(3) }
   end
 
   context 'should set available attribute' do

--- a/spec/models/discipline_spec.rb
+++ b/spec/models/discipline_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Discipline, type: :model do
     let(:discipline) { create(:discipline) }
 
     before do
-      create_list(:team, 3, disciplines: [ discipline ])
+      create_list(:team, 3, disciplines: [discipline])
       discipline.reload
     end
 

--- a/spec/models/team_discipline_spec.rb
+++ b/spec/models/team_discipline_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe TeamDiscipline, type: :model do
+  context 'association' do
+    it { is_expected.to belong_to(:team) }
+    it { is_expected.to belong_to(:discipline) }
+  end
+end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -10,9 +10,18 @@ RSpec.describe Team, type: :model do
 
     before do
       create_list(:user, 3, teams: [ team ])
-      team.reload
     end
 
     it { expect(team.users.size).to eq(3) }
+  end
+
+  context 'team has many disciplines' do
+    let(:team) { create(:team) }
+
+    before do
+      create_list(:discipline, 3, teams: [ team ])
+    end
+
+    it { expect(team.disciplines.size).to eq(3) }
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Team, type: :model do
+  context 'validates' do
+    it { is_expected.to validate_presence_of(:name) }
+  end
+end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Team, type: :model do
     let(:team) { create(:team) }
 
     before do
-      create_list(:user, 3, teams: [ team ])
+      create_list(:user, 3, teams: [team])
     end
 
     it { expect(team.users.size).to eq(3) }
@@ -19,7 +19,7 @@ RSpec.describe Team, type: :model do
     let(:team) { create(:team) }
 
     before do
-      create_list(:discipline, 3, teams: [ team ])
+      create_list(:discipline, 3, teams: [team])
     end
 
     it { expect(team.disciplines.size).to eq(3) }

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,7 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
-  context 'validates' do
-    it { is_expected.to validate_presence_of(:name) }
+  context 'association' do
+    it { is_expected.to have_many(:users) }
+  end
+
+  context 'team has many users' do
+    let(:team) { create(:team) }
+
+    before do
+      create_list(:user, 3, teams: [ team ])
+      team.reload
+    end
+
+    it { expect(team.users.size).to eq(3) }
   end
 end

--- a/spec/models/team_user_spec.rb
+++ b/spec/models/team_user_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe TeamUser, type: :model do
+  context 'association' do
+    it { is_expected.to belong_to(:team) }
+    it { is_expected.to belong_to(:user) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,9 +8,21 @@ RSpec.describe User, type: :model do
   end
 
   context 'association' do
-    it { is_expected.to have_many(:sessions) }
-    it { is_expected.to have_one(:profile) }
     it { is_expected.to belong_to(:school) }
+    it { is_expected.to have_many(:sessions) }
+    it { is_expected.to have_many(:teams) }
+    it { is_expected.to have_one(:profile) }
+  end
+
+  context 'user is on multiple teams' do
+    let(:user) { create(:user) }
+
+    before do
+      create_list(:team, 3, users: [user])
+      user.reload
+    end
+
+    it { expect(user.teams.size).to eq(3) }
   end
 
   context '#normalizes' do


### PR DESCRIPTION
## ⛏️ Motivação
Permitir manejar melhor os alunos cadastrados. Agora os alunos podem está vinculados a uma turma e esta turma pode conter muitas disciplinas vinculadas. Este gerenciamento permite transferir os alunos de turmas, caso, eles não consigam por algum motivo concluir o treinamento em vigor.

## ✅ Proposta
Adicionar modelo de times
Adicionar modelo que faz associação entre times e usuários
Adicionar modelo que faz associação entre times e disciplinas

