### PR TITLE
fix(disciplines): Adiciona seleção de turma no formulário de criação de disciplinas

### DIFF
--- a/app/controllers/admin/disciplines_controller.rb
+++ b/app/controllers/admin/disciplines_controller.rb
@@ -7,10 +7,12 @@ module Admin
 
     def new
       @discipline = Discipline.new
+      @team_names = Team.pluck(:name)
     end
 
     def create
-      @discipline = Discipline.new(discipline_params)
+      @discipline = Discipline.new(discipline_params.except(:team_name)
+                                                    .merge(teams: [team]))
 
       return redirect_to admin_disciplines_path, notice: I18n.t('messages.create.success', title: 'Disciplína') if @discipline.save
 
@@ -24,7 +26,11 @@ module Admin
     end
 
     def discipline_params
-      params.expect(discipline: %i[title abstract position body available_on])
+      params.expect(discipline: %i[title abstract position body available_on team_name])
+    end
+
+    def team
+      Team.find_by(name: discipline_params[:team_name])
     end
   end
 end

--- a/app/views/admin/disciplines/new.html.erb
+++ b/app/views/admin/disciplines/new.html.erb
@@ -22,6 +22,12 @@
           <%= form.label :available_on, class:"uk-form-label" %>
           <%= form.datetime_local_field :available_on, class:"uk-input" %>
         </div>
+        <div class="uk-margin">
+          <%= form.label :team_name, 'Turma', class:"uk-form-label" %>
+          <div class="uk-form-controls">
+            <%= form.select :team_name, @team_names, { }, { class:"uk-select" } %>
+          </div>
+        </div>
         <div class="uk-margin uk-text-right">
           <%= form.submit class: 'uk-button uk-button-default'  %>
         </div>

--- a/spec/controllers/admin/disciplines_controller_spec.rb
+++ b/spec/controllers/admin/disciplines_controller_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe Admin::DisciplinesController, type: :controller do
 
   describe 'POST #create' do
     let(:user) { create(:user, :admin) }
+    let(:team) { create(:team) }
 
     context 'create a discipline' do
       let(:params) do
@@ -82,7 +83,8 @@ RSpec.describe Admin::DisciplinesController, type: :controller do
             abstract: 'Tudo sobre tecnologia',
             body: 'Introdução a disciplina de tecnologia da informação',
             available_on: DateTime.current.to_s,
-            position: 1
+            position: 1,
+            team_name: team.name
           }
         }
       end

--- a/spec/system/admin/disciplines/new_spec.rb
+++ b/spec/system/admin/disciplines/new_spec.rb
@@ -4,6 +4,10 @@ feature Admin::DisciplinesController do
   let(:admin_user) { create(:user, :with_profile, :admin) }
   let(:discipline) { Discipline.last }
 
+  before do
+    create(:team, name: 'Colégio Estadual Roberto Santos - Turma 01')
+  end
+
   scenario 'admin create discipline' do
     login_as(admin_user)
     click_on 'Disciplinas'
@@ -13,6 +17,7 @@ feature Admin::DisciplinesController do
     fill_in  'Conteúdo', with: 'Introdução a disciplina de tecnologia da informação'
     fill_in  'Disponível em', with: Time.zone.local(2025, 10, 12, 12, 0, 0)
     fill_in  'Posição', with: '1'
+    select   'Colégio Estadual Roberto Santos - Turma 01', from: 'Turma'
     click_on 'Criar Disciplina'
 
     expect(current_path).to eq(admin_disciplines_path)
@@ -21,5 +26,6 @@ feature Admin::DisciplinesController do
     expect(I18n.l(discipline.available_on, format: :short)).to eq('12 de outubro, 12:00')
     expect(page).to have_content('Disciplína criado(a) com sucesso.')
     expect(discipline.position).to eq(1)
+    expect(discipline.teams.last.name).to eq('Colégio Estadual Roberto Santos - Turma 01')
   end
 end


### PR DESCRIPTION
## ⛏️ Motivação
Disciplinas precisam está vinculadas a uma turma.

## ✅ Proposta

- fix(disciplines): Adiciona seleção de turma no formulário de criação de disciplinas

![Screenshot 2025-03-03 at 14 54 08](https://github.com/user-attachments/assets/f4d01d2c-256c-45cf-a69d-2c1d0afb2ecd)

## 🗂️ Arquivos
