### PR TITLE
Cria página de edição de disciplina

### DIFF
--- a/app/controllers/admin/disciplines_controller.rb
+++ b/app/controllers/admin/disciplines_controller.rb
@@ -10,6 +10,8 @@ module Admin
       @team_names = Team.pluck(:name)
     end
 
+    def edit; end
+
     def create
       @discipline = Discipline.new(discipline_params.except(:team_name)
                                                     .merge(teams: [team]))

--- a/app/controllers/admin/disciplines_controller.rb
+++ b/app/controllers/admin/disciplines_controller.rb
@@ -2,37 +2,54 @@
 
 module Admin
   class DisciplinesController < AdminController
-    before_action :set_disciplines, only: %i[index]
-    def index; end
+    before_action :set_discipline, :set_teams, only: %i[edit update]
+    before_action :set_teams, only: %i[new create edit]
+
+    def index
+      @disciplines = Discipline.includes(teams: %i[users]).limit(15)
+    end
 
     def new
       @discipline = Discipline.new
-      @team_names = Team.pluck(:name)
     end
 
     def edit; end
 
     def create
       @discipline = Discipline.new(discipline_params.except(:team_name)
-                                                    .merge(teams: [team]))
+                                                    .merge(teams: teams))
 
-      return redirect_to admin_disciplines_path, notice: I18n.t('messages.create.success', title: 'Disciplína') if @discipline.save
+      render :new unless @discipline.save
 
-      render :new
+      redirect_to admin_disciplines_path, notice: I18n.t('messages.create.success', title: 'Disciplína') if @discipline.save
+    end
+
+    def update
+      @discipline.update(discipline_params.except(:team_ids).merge(teams: teams))
+
+      render :edit unless @discipline.persisted?
+
+      redirect_to admin_disciplines_path, notice: I18n.t('messages.update.success', title: 'Disciplína')
+    end
+
+    def set_teams
+      @teams = Team.all
     end
 
     private
 
-    def set_disciplines
-      @disciplines = Discipline.includes(teams: %i[users]).limit(15)
+    def set_discipline
+      @discipline = Discipline.includes(:teams).find(params[:id])
     end
 
+    # rubocop:disable Rails/StrongParametersExpect
     def discipline_params
-      params.expect(discipline: %i[title abstract position body available_on team_name])
+      params.require(:discipline).permit(:title, :abstract, :position, :body, :available_on, { team_ids: [] })
     end
+    # rubocop:enable Rails/StrongParametersExpect
 
-    def team
-      Team.find_by(name: discipline_params[:team_name])
+    def teams
+      Team.where(id: discipline_params[:team_ids])
     end
   end
 end

--- a/app/views/admin/disciplines/_form.html.erb
+++ b/app/views/admin/disciplines/_form.html.erb
@@ -2,26 +2,41 @@
   <div class="uk-margin">
     <%= form.label :title, class:"uk-form-label" %>
     <%= form.text_field :title, class:"uk-input" %>
+    <small class="uk-text-danger">
+      <%= @discipline&.errors.full_messages_for(:title).join.capitalize %>
+    </small>
   </div>
 
   <div class="uk-margin">
     <%= form.label :abstract, class:"uk-form-label" %>
     <%= form.text_field :abstract, class:"uk-input" %>
+    <small class="uk-text-danger">
+      <%= @discipline&.errors.full_messages_for(:abstract).join.capitalize %>
+    </small>
   </div>
 
   <div class="uk-margin">
     <%= form.label :body, class:"uk-form-label" %>
     <%= form.textarea :body, class:"uk-textarea" %>
+    <small class="uk-text-danger">
+      <%= @discipline&.errors.full_messages_for(:body).join.capitalize %>
+    </small>
   </div>
 
   <div class="uk-margin">
     <%= form.label :position, class:"uk-form-label" %>
     <%= form.number_field :position, class:"uk-input" %>
+    <small class="uk-text-danger">
+      <%= @discipline&.errors.full_messages_for(:position).join.capitalize %>
+    </small>
   </div>
 
   <div class="uk-margin">
     <%= form.label :available_on, class:"uk-form-label" %>
     <%= form.datetime_local_field :available_on, class:"uk-input" %>
+    <small class="uk-text-danger">
+      <%= @discipline&.errors.full_messages_for(:available_on).join.capitalize %>
+    </small>
   </div>
 
   <div class="uk-margin uk-grid-small uk-child-width-auto uk-grid">

--- a/app/views/admin/disciplines/_form.html.erb
+++ b/app/views/admin/disciplines/_form.html.erb
@@ -1,0 +1,42 @@
+<%= form_with model: @discipline, url: route_path, data: { turbo: false }, remote: false do | form | %>
+  <div class="uk-margin">
+    <%= form.label :title, class:"uk-form-label" %>
+    <%= form.text_field :title, class:"uk-input" %>
+  </div>
+
+  <div class="uk-margin">
+    <%= form.label :abstract, class:"uk-form-label" %>
+    <%= form.text_field :abstract, class:"uk-input" %>
+  </div>
+
+  <div class="uk-margin">
+    <%= form.label :body, class:"uk-form-label" %>
+    <%= form.textarea :body, class:"uk-textarea" %>
+  </div>
+
+  <div class="uk-margin">
+    <%= form.label :position, class:"uk-form-label" %>
+    <%= form.number_field :position, class:"uk-input" %>
+  </div>
+
+  <div class="uk-margin">
+    <%= form.label :available_on, class:"uk-form-label" %>
+    <%= form.datetime_local_field :available_on, class:"uk-input" %>
+  </div>
+
+  <div class="uk-margin uk-grid-small uk-child-width-auto uk-grid">
+    <div>
+      <%= form.label :team_ids, 'Turmas', class:"uk-form-label" %>
+      <%= form.collection_check_boxes(:team_ids, @teams, :id, :name, {}, { class: 'uk-checkbox' }) do |b| %>
+        <label>
+          <%= b.check_box %>
+          <%= b.text %>
+        </label>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="uk-margin uk-text-right">
+    <%= form.submit class: 'uk-button uk-button-default'  %>
+  </div>
+<% end %>

--- a/app/views/admin/disciplines/edit.html.erb
+++ b/app/views/admin/disciplines/edit.html.erb
@@ -1,0 +1,7 @@
+<section class="uk-section">
+  <div class="uk-container uk-container-small">
+    <div class="uk-card uk-card-secondary uk-card-body">
+      <%= render 'form', route_path: admin_discipline_path(@discipline) %>
+    </div>
+  </div>
+</section>

--- a/app/views/admin/disciplines/index.html.erb
+++ b/app/views/admin/disciplines/index.html.erb
@@ -16,30 +16,35 @@
       <table class="uk-table uk-table-middle uk-table-divider" id="disciplines">
         <thead>
           <tr>
-            <th class="uk-width-small">Título</th>
+            <th>Título</th>
             <th>Turmas vinculadas</th>
             <th>Total de alunos cadastrados</th>
             <th>Disponibilizado em</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
           <% @disciplines.each do |discipline| %>
             <tr class="discipline">
-              <th class="uk-width-small">
+              <th>
                 <%= discipline.title %>
               </th>
-              <th class="uk-width-small">
+              <th>
                 <% discipline.teams.each do |team| %>
                   <span class="uk-label">
                     <%= team.name %>
                   </span>
                 <% end %>
               </th>
-              <th class="uk-width-small">
+              <th >
                 <%= discipline.users.count %>
               </th>
-              <th class="uk-width-small">
+              <th >
                 <%= I18n.l(discipline.available_on, format: :short) %>
+              </th>
+              <th>
+                <%= link_to '', edit_admin_discipline_path(discipline), class: 'uk-icon-button',
+                            data: { uk_icon: "pencil" }, title: 'Editar' %>
               </th>
             </tr>
           <% end %>

--- a/app/views/admin/disciplines/new.html.erb
+++ b/app/views/admin/disciplines/new.html.erb
@@ -4,4 +4,4 @@
       <%= render 'form', route_path: admin_disciplines_path  %>
     </div>
   </div>
-</div>
+</section>

--- a/app/views/admin/disciplines/new.html.erb
+++ b/app/views/admin/disciplines/new.html.erb
@@ -1,37 +1,7 @@
 <section class="uk-section">
   <div class="uk-container uk-container-small">
     <div class="uk-card uk-card-secondary uk-card-body">
-      <%= form_with model: @discipline, url: admin_disciplines_path do | form | %>
-        <div class="uk-margin">
-          <%= form.label :title, class:"uk-form-label" %>
-          <%= form.text_field :title, class:"uk-input" %>
-        </div>
-        <div class="uk-margin">
-          <%= form.label :abstract, class:"uk-form-label" %>
-          <%= form.text_field :abstract, class:"uk-input" %>
-        </div>
-        <div class="uk-margin">
-          <%= form.label :body, class:"uk-form-label" %>
-          <%= form.textarea :body, class:"uk-textarea" %>
-        </div>
-        <div class="uk-margin">
-          <%= form.label :position, class:"uk-form-label" %>
-          <%= form.number_field :position, class:"uk-input" %>
-        </div>
-        <div class="uk-margin">
-          <%= form.label :available_on, class:"uk-form-label" %>
-          <%= form.datetime_local_field :available_on, class:"uk-input" %>
-        </div>
-        <div class="uk-margin">
-          <%= form.label :team_name, 'Turma', class:"uk-form-label" %>
-          <div class="uk-form-controls">
-            <%= form.select :team_name, @team_names, { }, { class:"uk-select" } %>
-          </div>
-        </div>
-        <div class="uk-margin uk-text-right">
-          <%= form.submit class: 'uk-button uk-button-default'  %>
-        </div>
-      <% end %>
+      <%= render 'form', route_path: admin_disciplines_path  %>
     </div>
   </div>
 </div>

--- a/config/locales/default_pt-BR.yml
+++ b/config/locales/default_pt-BR.yml
@@ -1,7 +1,7 @@
 ---
 pt-BR:
   messages:
-    update:
-      success: "%{alias_name} atualizado com sucesso."
     create:
       success: "%{title} criado(a) com sucesso."
+    update:
+      success: Registro atualizado com sucesso.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       get 'search',  to: 'users#search',  on: :collection
       get 'block',   to: 'users#block', on: :member
     end
-    resources :disciplines, only: %i[index new create edit update]
+    resources :disciplines, except: %i[show]
   end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
       get 'search',  to: 'users#search',  on: :collection
       get 'block',   to: 'users#block', on: :member
     end
-    resources :disciplines, only: %i[index new create]
+    resources :disciplines, only: %i[index new create edit update]
   end
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/spec/controllers/admin/disciplines_controller_spec.rb
+++ b/spec/controllers/admin/disciplines_controller_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Admin::DisciplinesController, type: :controller do
-  describe 'GET #index' do
-    let(:user) { create(:user, :admin) }
+  let(:user) { create(:user, :admin) }
 
-    context 'authorized user' do
+  describe 'GET #index' do
+    context '#index' do
       let!(:disciplines) { create_list(:discipline, 2) }
 
       before do
@@ -26,83 +26,120 @@ RSpec.describe Admin::DisciplinesController, type: :controller do
     end
 
     context 'without authorization' do
-      let(:disciplines) { create_list(:discipline, 2) }
-
-      before do
-        get :index
-      end
-
-      it 'unassigns authorization' do
-        expect(assigns(:disciplines)).not_to eq(disciplines)
-      end
-
-      it 'cannot render the index template' do
-        expect(response).not_to render_template(:index)
-      end
-
-      it '0 disciplines assigned' do
-        expect(assigns(:disciplines)).to be_nil
-      end
+      it_behaves_like 'unauthorized access', :get, :index
     end
   end
 
   describe 'GET #new' do
-    let(:user) { create(:user, :admin) }
-
-    context 'successfully' do
+    context 'authorized user' do
       before do
         sign_in(user)
         get :new
       end
 
-      it 'renders the index template' do
+      it 'renders the new template' do
         expect(response).to render_template(:new)
       end
     end
 
     context 'without authorization' do
-      before do
-        get :new
-      end
-
-      it 'cannot render the index template' do
-        expect(response).not_to render_template(:index)
-      end
+      it_behaves_like 'unauthorized access', :get, :new
     end
   end
 
   describe 'POST #create' do
-    let(:user) { create(:user, :admin) }
     let(:team) { create(:team) }
-
-    context 'create a discipline' do
-      let(:params) do
-        {
-          discipline: {
-            title: 'Introdução a tecnologia',
-            abstract: 'Tudo sobre tecnologia',
-            body: 'Introdução a disciplina de tecnologia da informação',
-            available_on: DateTime.current.to_s,
-            position: 1,
-            team_name: team.name
-          }
+    let(:params) do
+      {
+        discipline: {
+          title: 'Introdução a tecnologia',
+          abstract: 'Tudo sobre tecnologia',
+          body: 'Introdução a disciplina de tecnologia da informação',
+          available_on: DateTime.current.to_s,
+          position: 1,
+          team_name: team.name
         }
-      end
+      }
+    end
 
-      it 'successfully' do
-        sign_in(user)
+    context 'authorized user' do
+      before { sign_in(user) }
+
+      it 'creates a discipline successfully' do
         post :create, params: params
 
         expect(flash[:notice]).to eq('Disciplína criado(a) com sucesso.')
         expect(Discipline.count).to eq 1
       end
+    end
 
-      it 'no authorization' do
+    context 'without authorization' do
+      before do
         post :create, params: params
+      end
 
+      it 'does not create a discipline' do
         expect(flash[:notice]).to be_nil
         expect(Discipline.count).to be_zero
       end
     end
+
+    context 'without authorization' do
+      it_behaves_like 'unauthorized access', :get, :create, { id: 1 }
+    end
+  end
+
+  describe 'GET #edit' do
+    context '#edits' do
+      let(:discipline) { create(:discipline) }
+
+      before do
+        sign_in(user)
+        get :edit, params: { id: discipline.id }
+      end
+
+      it 'renders the edit template' do
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context 'without authorization' do
+      it_behaves_like 'unauthorized access', :get, :edit, { id: 1 }
+    end
+  end
+
+  describe 'UPDATE #update' do
+    let(:discipline) { create(:discipline, position: 1) }
+    let(:params) do
+      {
+        id: discipline.id,
+        discipline: {
+          title: 'Introdução aos algoritmos',
+          abstract: 'Aprenda a criar algoritimos',
+          body: 'Conteúdo sobre algoritmos',
+          available_on: Time.zone.local(2025, 10, 12, 8, 0, 0),
+          position: 2,
+          team_name: create(:team, name: 'Colegio Salvador - Turma 03').name
+        }
+      }
+    end
+
+    context 'successfuly' do
+      before { sign_in(user) }
+
+      it 'updates discipline' do
+        put :update, params: params
+        discipline.reload
+
+        expect(flash[:notice]).to eq('Registro atualizado com sucesso.')
+        expect(discipline.title).to eq 'Introdução aos algoritmos'
+        expect(discipline.abstract).to eq 'Aprenda a criar algoritimos'
+        expect(discipline.body).to eq 'Conteúdo sobre algoritmos'
+        expect(I18n.l(discipline.available_on, format: :short)).to eq '12 de outubro, 08:00'
+        expect(discipline.position).to eq 2
+      end
+    end
+
+    it_behaves_like 'unauthorized access', :put, :update, id: 1
   end
 end

--- a/spec/routes/admin/disciplines_spec.rb
+++ b/spec/routes/admin/disciplines_spec.rb
@@ -27,4 +27,13 @@ RSpec.describe 'User', type: :routing do
       )
     end
   end
+  context 'GET /admin/disciplines/1/edit' do
+    it do
+      expect(get: '/admin/disciplines/1/edit').to route_to(
+        controller: 'admin/disciplines',
+        action: 'edit',
+        id: '1'
+      )
+    end
+  end
 end

--- a/spec/support/unauthorized_shared_examples.rb
+++ b/spec/support/unauthorized_shared_examples.rb
@@ -1,0 +1,15 @@
+RSpec.shared_examples 'unauthorized access' do |http_method, action, params = {}|
+  before { send(http_method, action, params: params) }
+
+  it 'redirects to login' do
+    expect(response).to redirect_to(new_session_path)
+  end
+
+  it 'does not render the template' do
+    expect(response).not_to render_template(action)
+  end
+
+  it 'does not create a discipline' do
+    expect(flash[:notice]).to be_nil
+  end
+end

--- a/spec/system/admin/disciplines/edit_spec.rb
+++ b/spec/system/admin/disciplines/edit_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+feature Admin::DisciplinesController do
+  let(:admin_user) { create(:user, :with_profile, :admin) }
+  let(:discipline) { create(:discipline) }
+
+  before do
+    team1 = create(:team, name: 'Colégio Estadual Roberto Santos - Turma 01')
+    discipline.teams << [team1]
+    discipline.save!
+
+    login_as(admin_user)
+    visit admin_disciplines_path
+  end
+
+  scenario 'edits discipline' do
+    create(:team, name: 'Colégio Estadual Deputado Luis Eduardo Magalhaes - Turma 03')
+
+    find('a[title="Editar"]').click
+    fill_in  'Título', with: 'Introdução a computação - Segunda edição'
+    fill_in  'Resumo', with: 'Resumo editado'
+    fill_in  'Conteúdo', with: 'Conteúdo da disciplina'
+    fill_in  'Disponível em', with: Time.zone.local(2025, 12, 1, 9, 0, 0)
+    fill_in  'Posição', with: '2'
+    find(:css, "#discipline_team_ids_2[value='2']").set(true)
+    click_on 'Atualizar Disciplina'
+    discipline.reload
+
+    expect(discipline.title).to eq('Introdução a computação - Segunda edição')
+    expect(discipline.abstract).to eq('Resumo editado')
+    expect(discipline.body).to eq('Conteúdo da disciplina')
+    expect(I18n.l(discipline.available_on, format: :short)).to eq('01 de dezembro, 09:00')
+    expect(discipline.position).to eq(2)
+    expect(discipline.teams.first.name).to eq('Colégio Estadual Roberto Santos - Turma 01')
+    expect(discipline.teams.last.name).to eq('Colégio Estadual Deputado Luis Eduardo Magalhaes - Turma 03')
+    expect(page).to have_content('Registro atualizado com sucesso.')
+  end
+
+  scenario 'remove all associate teams' do
+    find('a[title="Editar"]').click
+    find(:css, "#discipline_team_ids_1[value='1']").set(false)
+    click_on 'Atualizar Disciplina'
+
+    expect(discipline.reload.teams.count).to eq(0)
+    expect(page).to have_content('Registro atualizado com sucesso.')
+  end
+end

--- a/spec/system/admin/disciplines/new_spec.rb
+++ b/spec/system/admin/disciplines/new_spec.rb
@@ -28,4 +28,16 @@ feature Admin::DisciplinesController do
     expect(discipline.position).to eq(1)
     expect(discipline.teams.last.name).to eq('Colégio Estadual Roberto Santos - Turma 01')
   end
+
+  scenario 'creates without fields' do
+    login_as(admin_user)
+    click_on 'Disciplinas'
+    click_on 'Adicionar'
+    click_on 'Criar Disciplina'
+
+    expect(page).to have_content('Título não pode ficar em branco')
+    expect(page).to have_content('Resumo não pode ficar em branco')
+    expect(page).to have_content('Conteúdo não pode ficar em branco')
+    expect(page).to have_content('Disponível em não pode ficar em branco')
+  end
 end

--- a/spec/system/admin/disciplines/new_spec.rb
+++ b/spec/system/admin/disciplines/new_spec.rb
@@ -17,7 +17,7 @@ feature Admin::DisciplinesController do
     fill_in  'Conteúdo', with: 'Introdução a disciplina de tecnologia da informação'
     fill_in  'Disponível em', with: Time.zone.local(2025, 10, 12, 12, 0, 0)
     fill_in  'Posição', with: '1'
-    select   'Colégio Estadual Roberto Santos - Turma 01', from: 'Turma'
+    find(:css, "#discipline_team_ids_1[value='1']").set(true)
     click_on 'Criar Disciplina'
 
     expect(current_path).to eq(admin_disciplines_path)

--- a/spec/system/pages/profiles/edit_spec.rb
+++ b/spec/system/pages/profiles/edit_spec.rb
@@ -20,7 +20,7 @@ feature ProfilesController do
 
       expect(current_path).to eq(profile_path)
       expect(page).to have_content('angelica@example.com')
-      expect(page).to have_content('E-mail atualizado com sucesso')
+      expect(page).to have_content('Registro atualizado com sucesso')
       expect(user.reload.email_address).to eq('angelica@example.com')
     end
 


### PR DESCRIPTION
## ⛏️ Motivação
Admin pode editar disciplinas para ofertar o melhor conteúdo para os alunos

## ✅ Proposta
Criar página de edição de disciplina e permitir vincular disciplina a uma ou mais turmas.

## 🌄 Imagens
![Screenshot 2025-03-09 at 17 51 04](https://github.com/user-attachments/assets/10da264c-c5d2-4daa-a526-bf42eba8a3d6)
