### PR TITLE
Melhora a apresentação dos formulários e renomeia rótulos para maior clareza

### DIFF
--- a/app/views/admin/disciplines/_form.html.erb
+++ b/app/views/admin/disciplines/_form.html.erb
@@ -1,47 +1,57 @@
-<%= form_with model: @discipline, url: route_path, data: { turbo: false } do | form | %>
+<%= form_with model: @discipline, url: route_path, class: 'uk-form-horizontal', data: { turbo: false } do | form | %>
   <div class="uk-margin">
     <%= form.label :title, class:"uk-form-label" %>
-    <%= form.text_field :title, class:"uk-input" %>
-    <small class="uk-text-danger">
-      <%= @discipline&.errors.full_messages_for(:title).join.capitalize %>
-    </small>
+    <div class="uk-form-controls" >
+      <%= form.text_field :title, class:"uk-input" %>
+      <small class="uk-text-danger">
+        <%= @discipline&.errors.full_messages_for(:title).join.capitalize %>
+      </small>
+    </div>
   </div>
 
   <div class="uk-margin">
     <%= form.label :abstract, class:"uk-form-label" %>
-    <%= form.text_field :abstract, class:"uk-input" %>
-    <small class="uk-text-danger">
-      <%= @discipline&.errors.full_messages_for(:abstract).join.capitalize %>
-    </small>
+    <div class="uk-form-controls" >
+      <%= form.text_field :abstract, class:"uk-input" %>
+      <small class="uk-text-danger">
+        <%= @discipline&.errors.full_messages_for(:abstract).join.capitalize %>
+      </small>
+    </div>
   </div>
 
   <div class="uk-margin">
     <%= form.label :body, class:"uk-form-label" %>
-    <%= form.textarea :body, class:"uk-textarea" %>
-    <small class="uk-text-danger">
-      <%= @discipline&.errors.full_messages_for(:body).join.capitalize %>
-    </small>
+    <div class="uk-form-controls" >
+      <%= form.textarea :body, class:"uk-textarea" %>
+      <small class="uk-text-danger">
+        <%= @discipline&.errors.full_messages_for(:body).join.capitalize %>
+      </small>
+    </div>
   </div>
 
   <div class="uk-margin">
     <%= form.label :position, class:"uk-form-label" %>
-    <%= form.number_field :position, class:"uk-input" %>
-    <small class="uk-text-danger">
-      <%= @discipline&.errors.full_messages_for(:position).join.capitalize %>
-    </small>
+    <div class="uk-form-controls" >
+      <%= form.number_field :position, class:"uk-input" %>
+      <small class="uk-text-danger">
+        <%= @discipline&.errors.full_messages_for(:position).join.capitalize %>
+      </small>
+    </div>
   </div>
 
   <div class="uk-margin">
     <%= form.label :available_on, class:"uk-form-label" %>
-    <%= form.datetime_local_field :available_on, class:"uk-input" %>
-    <small class="uk-text-danger">
-      <%= @discipline&.errors.full_messages_for(:available_on).join.capitalize %>
-    </small>
+    <div class="uk-form-controls" >
+      <%= form.datetime_local_field :available_on, class:"uk-input" %>
+      <small class="uk-text-danger">
+        <%= @discipline&.errors.full_messages_for(:available_on).join.capitalize %>
+      </small>
+    </div>
   </div>
 
-  <div class="uk-margin uk-grid-small uk-child-width-auto uk-grid">
-    <div>
-      <%= form.label :team_ids, 'Turmas', class:"uk-form-label" %>
+  <div class="uk-margin">
+    <%= form.label :team_ids, 'Turmas', class:"uk-form-label" %>
+     <div class="uk-form-controls uk-form-controls-text">
       <%= form.collection_check_boxes(:team_ids, @teams, :id, :name, {}, { class: 'uk-checkbox' }) do |b| %>
         <label>
           <%= b.check_box %>

--- a/app/views/admin/disciplines/index.html.erb
+++ b/app/views/admin/disciplines/index.html.erb
@@ -18,7 +18,7 @@
           <tr>
             <th>Título</th>
             <th>Turmas vinculadas</th>
-            <th>Total de alunos cadastrados</th>
+            <th>Total de alunos</th>
             <th>Disponibilizado em</th>
             <th></th>
           </tr>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -17,7 +17,7 @@
               <div class="uk-navbar-dropdown">
                 <ul class="uk-nav uk-navbar-dropdown-nav">
                   <li>
-                    <%= link_to 'Alunos cadastrados', admin_users_path, class: 'uk-text-secondary' %>
+                    <%= link_to 'Alunos', admin_users_path, class: 'uk-text-secondary' %>
                     <%= link_to 'Disciplinas', admin_disciplines_path, class: 'uk-text-secondary' %>
                     <%= link_to 'Turmas', admin_teams_path, class: 'uk-text-secondary' %>
                   </li>

--- a/spec/system/admin/users/index_spec.rb
+++ b/spec/system/admin/users/index_spec.rb
@@ -91,7 +91,7 @@ feature Admin::UsersController do
     login_as(student)
 
     expect(page).not_to have_content('ADMIN')
-    expect(page).not_to have_content('Alunos cadastrados')
+    expect(page).not_to have_content('Alunos')
   end
 
   scenario 'user tries to access a direct route and gets redirected to the home page' do
@@ -102,7 +102,7 @@ feature Admin::UsersController do
 
     expect(current_path).to eq(root_path)
     expect(page).not_to have_content('ADMIN')
-    expect(page).not_to have_content('Alunos cadastrados')
+    expect(page).not_to have_content('Alunos')
   end
 
   scenario 'block user' do


### PR DESCRIPTION
## ✅ Proposta

- Melhorar a legibilidade dos títulos do menu
![Screenshot 2025-03-11 at 21 18 21](https://github.com/user-attachments/assets/f7fee179-bc17-48b8-8805-615c50fe0642)

- Melhorar a forma que o formulário se apresenta, colocando as _labels_ na horizontal.
![Screenshot 2025-03-11 at 21 02 07](https://github.com/user-attachments/assets/e8ad39b4-936a-4ac5-abfe-5248aac35cd1)


